### PR TITLE
Default acl

### DIFF
--- a/tinys3/connection.py
+++ b/tinys3/connection.py
@@ -101,7 +101,7 @@ class Base(object):
 
     def upload(self, key, local_file,
                bucket=None, expires=None, content_type=None,
-               public=True, headers=None, rewind=True, close=False):
+               public=False, headers=None, rewind=True, close=False):
         """
         Upload a file and store it under a key
 
@@ -151,7 +151,7 @@ class Base(object):
 
         return self.run(r)
 
-    def copy(self, from_key, from_bucket, to_key, to_bucket=None, metadata=None, public=True):
+    def copy(self, from_key, from_bucket, to_key, to_bucket=None, metadata=None, public=False):
         """
         Copy a key contents to another key/bucket with an option to update metadata/public state
 
@@ -179,7 +179,7 @@ class Base(object):
 
         return self.run(r)
 
-    def update_metadata(self, key, metadata=None, bucket=None, public=True):
+    def update_metadata(self, key, metadata=None, bucket=None, public=False):
         """
         Updates the metadata information for a file
 

--- a/tinys3/request_factory.py
+++ b/tinys3/request_factory.py
@@ -197,7 +197,7 @@ class UploadRequest(S3Request):
         else:
             expires = expires
 
-        return "max-age=%d" % self._get_total_seconds(expires) + ', public' if self.public else ''
+        return "max-age=%d" % self._get_total_seconds(expires) + (', public' if self.public else '')
 
     def _get_total_seconds(self, timedelta):
         """

--- a/tinys3/request_factory.py
+++ b/tinys3/request_factory.py
@@ -106,7 +106,7 @@ class ListRequest(S3Request):
 
 
 class UploadRequest(S3Request):
-    def __init__(self, conn, key, local_file, bucket, expires=None, content_type=None, public=True, extra_headers=None,
+    def __init__(self, conn, key, local_file, bucket, expires=None, content_type=None, public=False, extra_headers=None,
                  close=False, rewind=True):
         """
 
@@ -222,7 +222,7 @@ class DeleteRequest(S3Request):
 
 
 class CopyRequest(S3Request):
-    def __init__(self, conn, from_key, from_bucket, to_key, to_bucket, metadata=None, public=True):
+    def __init__(self, conn, from_key, from_bucket, to_key, to_bucket, metadata=None, public=False):
         super(CopyRequest, self).__init__(conn)
         self.from_key = from_key.lstrip('/')
         self.from_bucket = from_bucket
@@ -251,5 +251,5 @@ class CopyRequest(S3Request):
 
 
 class UpdateMetadataRequest(CopyRequest):
-    def __init__(self, conn, key, bucket, metadata=None, public=True):
+    def __init__(self, conn, key, bucket, metadata=None, public=False):
         super(UpdateMetadataRequest, self).__init__(conn, key, bucket, key, bucket, metadata=metadata, public=public)

--- a/tinys3/tests/test_non_upload_requests.py
+++ b/tinys3/tests/test_non_upload_requests.py
@@ -107,7 +107,7 @@ class TestNonUploadRequests(unittest.TestCase):
         Test the generation of a copy request
         """
 
-        r = CopyRequest(self.conn, 'from_key', 'from_bucket', 'to_key', 'to_bucket', None, False)
+        r = CopyRequest(self.conn, 'from_key', 'from_bucket', 'to_key', 'to_bucket', None)
 
         mock = self._mock_adapter(r)
 

--- a/tinys3/tests/test_upload_request.py
+++ b/tinys3/tests/test_upload_request.py
@@ -40,7 +40,6 @@ class TestUploadRequest(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'application/octet-stream'
         }
 
@@ -60,6 +59,33 @@ class TestUploadRequest(unittest.TestCase):
 
         return flexmock(raise_for_status=lambda: None)
 
+    def test_upload_public_acl(self):
+        """
+        Test automatic/explicit content type setting
+        """
+
+        # No need to test fallback case ('application/octet-stream'), because
+        # it was tested on the 'test_simple_upload' test
+
+        # Test auto content type guessing
+        r = UploadRequest(self.conn, 'test_zip_key.zip', self.dummy_data, 'bucket', public=True)
+
+        mock = self._mock_adapter(r)
+
+        expected_headers = {
+            'x-amz-acl': 'public-read',
+            'Content-Type': 'application/zip'
+        }
+
+        mock.should_receive('put').with_args(
+            'https://s3.amazonaws.com/bucket/test_zip_key.zip',
+            headers=expected_headers,
+            data=self.dummy_data,
+            auth=self.conn.auth
+        ).and_return(self._mock_response())
+
+        r.run()
+
     def test_upload_content_type(self):
         """
         Test automatic/explicit content type setting
@@ -74,7 +100,6 @@ class TestUploadRequest(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'application/zip'
         }
 
@@ -93,7 +118,6 @@ class TestUploadRequest(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'candy/smore'
         }
 
@@ -112,15 +136,13 @@ class TestUploadRequest(unittest.TestCase):
         """
 
         # Test max expiry headers
-
         r = UploadRequest(self.conn, 'test_zip_key.zip', self.dummy_data, 'bucket', expires='max')
 
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'application/zip',
-            'Cache-Control': 'max-age=31536000, public'
+            'Cache-Control': 'max-age=31536000',
         }
 
         mock.should_receive('put').with_args(
@@ -138,9 +160,8 @@ class TestUploadRequest(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'application/zip',
-            'Cache-Control': 'max-age=1337, public'
+            'Cache-Control': 'max-age=1337',
         }
 
         mock.should_receive('put').with_args(
@@ -153,15 +174,33 @@ class TestUploadRequest(unittest.TestCase):
         r.run()
 
         # Test timedelta expiry
-
         r = UploadRequest(self.conn, 'test_zip_key.zip', self.dummy_data, 'bucket', expires=timedelta(weeks=2))
+
+        mock = self._mock_adapter(r)
+
+        expected_headers = {
+            'Content-Type': 'application/zip',
+            'Cache-Control': 'max-age=1209600',
+        }
+
+        mock.should_receive('put').with_args(
+            'https://s3.amazonaws.com/bucket/test_zip_key.zip',
+            headers=expected_headers,
+            data=self.dummy_data,
+            auth=self.conn.auth
+        ).and_return(self._mock_response())
+
+        r.run()
+
+        # Test public
+        r = UploadRequest(self.conn, 'test_zip_key.zip', self.dummy_data, 'bucket', expires=42, public=True)
 
         mock = self._mock_adapter(r)
 
         expected_headers = {
             'x-amz-acl': 'public-read',
             'Content-Type': 'application/zip',
-            'Cache-Control': 'max-age=1209600, public'
+            'Cache-Control': 'max-age=42, public',
         }
 
         mock.should_receive('put').with_args(
@@ -184,7 +223,6 @@ class TestUploadRequest(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'application/zip',
             'example-meta-key': 'example-meta-value'
         }
@@ -209,7 +247,6 @@ class TestUploadRequest(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'application/zip',
         }
 
@@ -238,7 +275,6 @@ class TestUploadRequest(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         expected_headers = {
-            'x-amz-acl': 'public-read',
             'Content-Type': 'application/zip',
         }
 


### PR DESCRIPTION
The default ACL on S3 is `private` (which doesn't necessarily mean that the file are actually private, it can be overridden by a bucket policy for instance). Cf http://docs.aws.amazon.com/AmazonS3/latest/dev/ACLOverview.html
So, imho, tinys3 should offer the same default settings.

The second commit is a very small bugfix in `UploadRequest._calc_cache_control`, if this PR is refused the fix should still be applied to master (yet another PR for that seemed a tiny bit overkill)

Arthur
