### PR TITLE
Try setuptools first, then fallback to distutils to take advantage of automated installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError
+    from distutils.core import setup
 
 setup(name='tinys3',
       version='0.1.9',


### PR DESCRIPTION
While installing you can see this warning message:

> /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'

Since distutils does not support the [nice](http://pythonhosted.org/setuptools/setuptools.html#declaring-dependencies) `install_requires` keyword, it is not able to download and auto-install a package to resolve dependencies.

This changes adds support to setuptools and falling back to distutils, it is a safe approach.
