### PR TITLE
Missing colon.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 try:
     from setuptools import setup
-except ImportError
+except ImportError:
     from distutils.core import setup
 
 setup(name='tinys3',


### PR DESCRIPTION
There is a missing colon in setup.py that keeps the current checkout from being installed via that route.
