### PR TITLE
ListRequest to iterate over the files in a bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Features
 * Copy keys inside/between buckets
 * Delete keys
 * Update key metadata
+* List keys in a bucket
 * Simple way to set key as public or setting Cache-Control and Content-Type headers.
 * Pool implementation for fast multi-threaded actions
 
@@ -186,6 +187,16 @@ Deleting keys
 # Deleting keys is simple
 conn.delete('key.jpg','my_bucket')
 
+```
+
+Listing keys
+------------
+tinys3 will try to use lxml if it's available, otherwise it will fallback to xml python module
+(slower and not secure against maliciously constructed data)
+```python
+# This will return an iterator over the metadata of the files starting with 'prefix' in 'my_bucket'
+# The iterator will yield dicts with the following keys: key, etag, size, last_modified, storage_class
+conn.list('prefix', 'my_bucket')
 ```
 
 Using tinys3's Connection Pool

--- a/tinys3/connection.py
+++ b/tinys3/connection.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .auth import S3Auth
-from .request_factory import UploadRequest, UpdateMetadataRequest, CopyRequest, DeleteRequest, GetRequest
+from .request_factory import UploadRequest, UpdateMetadataRequest, CopyRequest, DeleteRequest, GetRequest, ListRequest
 
 
 class Base(object):
@@ -69,6 +69,33 @@ class Base(object):
 
         """
         r = GetRequest(self, key, self.bucket(bucket))
+
+        return self.run(r)
+
+    def list(self, prefix='', bucket=None):
+        """
+        List files
+
+        Params:
+            - prefix        (Optional) List only files starting with this prefix (default to the empty string)
+
+            - bucket        (Optional) The name of the bucket to use (can be skipped if setting the default_bucket)
+                            option for the connection
+
+        Returns:
+            - An iterator over the files, each file being represented by a dict object with the following keys:
+                - etag
+                - key
+                - last_modified
+                - size
+                - storage_class
+
+        Usage:
+
+        >>> conn.list('rep/','sample_bucket')
+
+        """
+        r = ListRequest(self, prefix, self.bucket(bucket))
 
         return self.run(r)
 

--- a/tinys3/tests/test_bucket_iterator.py
+++ b/tinys3/tests/test_bucket_iterator.py
@@ -1,1 +1,0 @@
-__author__ = 'shlomiatar'

--- a/tinys3/tests/test_list_request.py
+++ b/tinys3/tests/test_list_request.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+import datetime
+import unittest
+from flexmock import flexmock
+from tinys3.request_factory import ListRequest
+from tinys3 import Connection
+
+
+class TestNonUploadRequests(unittest.TestCase):
+    def setUp(self):
+        self.conn = Connection("TEST_ACCESS_KEY", "TEST_SECRET_KEY", tls=True)
+        self.r = ListRequest(self.conn, 'prefix', 'bucket')
+        
+        self.adapter = flexmock()
+        flexmock(self.r).should_receive('adapter').and_return(self.adapter)
+
+    def test_simple_list_request(self):
+        """
+        Test the generation of a list request
+        """
+
+        self.adapter.should_receive('get').with_args(
+            'https://s3.amazonaws.com/bucket/',
+            auth=self.conn.auth,
+            params={'prefix': 'prefix', 'marker': ''},
+        ).and_return(flexmock(raise_for_status=lambda: None, content=b"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>bucket</Name>
+                <Prefix>prefix</Prefix>
+                <Marker></Marker>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <Contents>
+                    <Key>prefix/file1</Key>
+                    <LastModified>2013-10-31T15:38:32.000Z</LastModified>
+                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
+                    <Size>0</Size>
+                    <StorageClass>STANDARD</StorageClass>
+                </Contents>
+                <Contents>
+                    <Key>prefix/file2</Key>
+                    <LastModified>2014-06-16T15:58:56.000Z</LastModified>
+                    <ETag>&quot;31ed785816f1162fca532cbc80b27266&quot;</ETag>
+                    <Size>581708</Size>
+                    <StorageClass>STANDARD</StorageClass>
+                </Contents>
+            </ListBucketResult>
+        """.strip())).once()
+
+        self.assertEquals(list(self.r.run()), [{
+            'etag': 'd41d8cd98f00b204e9800998ecf8427e',
+            'key': 'prefix/file1',
+            'last_modified': datetime.datetime(2013, 10, 31, 15, 38, 32),
+            'size': 0,
+            'storage_class': 'STANDARD',
+        }, {
+            'etag': '31ed785816f1162fca532cbc80b27266',
+            'key': 'prefix/file2',
+            'last_modified': datetime.datetime(2014, 6, 16, 15, 58, 56),
+            'size': 581708,
+            'storage_class': 'STANDARD',
+        }])
+
+    def test_chained_list_requests(self):
+        """
+        Test the generation of a more complex list request
+        """
+
+        self.adapter.should_receive('get').with_args(
+            'https://s3.amazonaws.com/bucket/',
+            auth=self.conn.auth,
+            params={'prefix': 'prefix', 'marker': ''},
+        ).and_return(flexmock(raise_for_status=lambda: None, content=b"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>bucket</Name>
+                <Prefix>prefix</Prefix>
+                <Marker></Marker>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>true</IsTruncated>
+                <Contents>
+                    <Key>prefix/file1</Key>
+                    <LastModified>2013-10-31T15:38:32.000Z</LastModified>
+                    <ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
+                    <Size>0</Size>
+                    <StorageClass>STANDARD</StorageClass>
+                </Contents>
+            </ListBucketResult>
+        """.strip())).once()
+
+        self.adapter.should_receive('get').with_args(
+            'https://s3.amazonaws.com/bucket/',
+            auth=self.conn.auth,
+            params={'prefix': 'prefix', 'marker': 'prefix/file1'},
+        ).and_return(flexmock(raise_for_status=lambda: None, content=b"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>bucket</Name>
+                <Prefix>prefix</Prefix>
+                <Marker>prefix/file1</Marker>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <Contents>
+                    <Key>prefix/file2</Key>
+                    <LastModified>2014-06-16T15:58:56.000Z</LastModified>
+                    <ETag>&quot;31ed785816f1162fca532cbc80b27266&quot;</ETag>
+                    <Size>581708</Size>
+                    <StorageClass>STANDARD</StorageClass>
+                </Contents>
+            </ListBucketResult>
+        """.strip())).once()
+
+        self.assertEquals(list(self.r.run()), [{
+            'etag': 'd41d8cd98f00b204e9800998ecf8427e',
+            'key': 'prefix/file1',
+            'last_modified': datetime.datetime(2013, 10, 31, 15, 38, 32),
+            'size': 0,
+            'storage_class': 'STANDARD',
+        }, {
+            'etag': '31ed785816f1162fca532cbc80b27266',
+            'key': 'prefix/file2',
+            'last_modified': datetime.datetime(2014, 6, 16, 15, 58, 56),
+            'size': 581708,
+            'storage_class': 'STANDARD',
+        }])

--- a/tinys3/tests/test_non_upload_requests.py
+++ b/tinys3/tests/test_non_upload_requests.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
-import mimetypes
 import unittest
 from flexmock import flexmock
 from tinys3.request_factory import CopyRequest, S3Request, UpdateMetadataRequest, DeleteRequest, GetRequest
 from tinys3 import Connection
-
-TEST_AUTH = ("TEST_ACCESS_KEY", "TEST_SECRET_KEY")
 
 
 class TestNonUploadRequests(unittest.TestCase):


### PR DESCRIPTION
Iterate over the metadata of the files in a bucket.

I tried to keep it simple, it uses lxml if available, other it fall backs to the native xml module.
The list request run method returns an iterator which will query the amazon API each times it needs more data
