### PR TITLE
make sure the flexmocked methods are actually called

### DIFF
--- a/tinys3/tests/test_non_upload_requests.py
+++ b/tinys3/tests/test_non_upload_requests.py
@@ -59,7 +59,7 @@ class TestNonUploadRequests(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         mock.should_receive('delete').with_args('https://s3.amazonaws.com/bucket/key_to_delete',
-                                                auth=self.conn.auth).and_return(self._mock_response())
+                                                auth=self.conn.auth).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -73,7 +73,7 @@ class TestNonUploadRequests(unittest.TestCase):
         mock = self._mock_adapter(r)
 
         mock.should_receive('get').with_args('https://s3.amazonaws.com/bucket/key_to_get',
-                                             auth=self.conn.auth).and_return(self._mock_response())
+                                             auth=self.conn.auth).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -98,7 +98,7 @@ class TestNonUploadRequests(unittest.TestCase):
             'https://s3.amazonaws.com/bucket/key_to_update',
             headers=expected_headers,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -120,7 +120,7 @@ class TestNonUploadRequests(unittest.TestCase):
             'https://s3.amazonaws.com/to_bucket/to_key',
             headers=expected_headers,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 

--- a/tinys3/tests/test_pool.py
+++ b/tinys3/tests/test_pool.py
@@ -77,7 +77,7 @@ class TestPool(unittest.TestCase):
 
         pool = Pool(TEST_ACCESS_KEY, TEST_SECRET_KEY)
 
-        flexmock(pool).should_receive('close')
+        flexmock(pool).should_receive('close').once()
 
         with pool as p:
             # do nothing

--- a/tinys3/tests/test_upload_request.py
+++ b/tinys3/tests/test_upload_request.py
@@ -49,7 +49,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -83,7 +83,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -102,7 +102,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -128,7 +128,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -148,7 +148,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -169,7 +169,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -194,7 +194,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -218,7 +218,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 
@@ -247,7 +247,7 @@ class TestUploadRequest(unittest.TestCase):
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
-        ).and_return(self._mock_response())
+        ).and_return(self._mock_response()).once()
 
         r.run()
 


### PR DESCRIPTION
Without the `.once()`, you can add a `return None` at the top of every `run` methods of the requests class and all the tests would still pass
