### PR TITLE
Use EAFP instead of hasattr() to check o.fileno

### DIFF
--- a/tinys3/util.py
+++ b/tinys3/util.py
@@ -62,12 +62,11 @@ class LenWrapperStream(object):
         if hasattr(o, 'len'):
             return o.len
 
-        # If we have a fileno property
-        if hasattr(o, 'fileno'):
-            try:
-                return os.fstat(o.fileno()).st_size
-            except IOError:
-                pass  # fallback to the manual way, this is useful when using something like BytesIO
+        # If we have a fileno property (EAFP here, because some file-like objs like tarfile "ExFileObject" will pass a hasattr test but still not work)
+        try:
+            return os.fstat(o.fileno()).st_size
+        except (IOError, AttributeError):
+            pass  # fallback to the manual way, this is useful when using something like BytesIO
 
 
         # calculate based on bytes to end of content


### PR DESCRIPTION
This will allow files being extracted via the tarfile module to be uploaded directly, without wrapping them in another file-like object.

Here's an example of the problem:

Code (abbreviated):

```
    with tarfile.open(fileobj=tarball_fd) as archive:
        for frame_number in range(1, 13):
            with archive.extractfile("frame{0:02d}.png".format(frame_number)) as fd: # using extractfile here protects the filesystem from any maliciously named files -- we only get a file descriptor, it doesn't get written to the filesystem
                key = "{base}_frame{frame_number}.png".format(base=tarball_hash, frame_number=frame_number)
                conn.upload(key, fd, settings.AWS_STORAGE_BUCKET_NAME, public=True)
```

Traceback:

```
  File "/home/andrewsg/src/gb/lib/python3.4/site-packages/tinys3/util.py", line 68, in __len__
    return os.fstat(o.fileno()).st_size
AttributeError: '_FileInFile' object has no attribute 'fileno'
```

pdb inspection:

```
> /home/andrewsg/src/gb/lib/python3.4/site-packages/tinys3/util.py(69)__len__()
-> return os.fstat(o.fileno()).st_size
(Pdb) o
<ExFileObject name='tarball.tar'>
(Pdb) hasattr(o, 'fileno')
True
(Pdb) o.fileno
<built-in method fileno of ExFileObject object at 0x7f3f46b9d1a8>
(Pdb) o.fileno()
*** AttributeError: '_FileInFile' object has no attribute 'fileno'
```
