### PR TITLE
Update request_factory.py

### DIFF
--- a/tinys3/request_factory.py
+++ b/tinys3/request_factory.py
@@ -140,7 +140,7 @@ class UploadRequest(S3Request):
         headers = {}
 
         # calc the expires headers
-        if self.expires:
+        if self.expires is not None:
             headers['Cache-Control'] = self._calc_cache_control()
 
         # calc the content type


### PR DESCRIPTION
When initialising UploadRequest with `expires=0` (zero), no Cache-Control header is set. It could be handy to set Cache-Control to max-age(0). This PR suggest a tiny change to make that possible:

`if self.expires is not None: ...`

instead of 

`if self.expires: ...`