### PR TITLE
Fix for setting Cache-Control on non-Public Files

### DIFF
--- a/tinys3/request_factory.py
+++ b/tinys3/request_factory.py
@@ -197,7 +197,7 @@ class UploadRequest(S3Request):
         else:
             expires = expires
 
-        return "max-age=%d" % self._get_total_seconds(expires) + ', public' if self.public else ''
+        return "max-age=%d" % self._get_total_seconds(expires) + (', public' if self.public else '')
 
     def _get_total_seconds(self, timedelta):
         """


### PR DESCRIPTION
If a file is not public the cache control header was written empty, rather than just missing the ,public suffice. Small operator precedence bug :)