### PR TITLE
Add option to use different url format to connect to bucket.

### DIFF
--- a/tinys3/connection.py
+++ b/tinys3/connection.py
@@ -15,8 +15,11 @@ class Base(object):
     This is an "abstract" class, both Connection and Pool implement it.
     """
 
+    BUCKET_URL_FORMAT_SUBDOMAIN = 'BUCKET_URL_FORMAT_SUBDOMAIN'
+    BUCKET_URL_FORMAT_FOLDER = 'BUCKET_URL_FORMAT_FOLDER'
+
     def __init__(self, access_key, secret_key, default_bucket=None, tls=False,
-                 endpoint="s3.amazonaws.com"):
+                 endpoint="s3.amazonaws.com", bucket_url_format=BUCKET_URL_FORMAT_SUBDOMAIN):
         """
         Creates a new S3 connection
 
@@ -29,12 +32,14 @@ class Base(object):
             - tls               (Optional) Make the requests using secure
               connection (Defaults to False)
             - endpoint          (Optional) Sets the s3 endpoint.
+            - bucket_url_format (Optional) Format url used to connect to bucket
 
         """
         self.default_bucket = default_bucket
         self.auth = S3Auth(access_key, secret_key)
         self.tls = tls
         self.endpoint = endpoint
+        self.bucket_url_format = bucket_url_format
 
     def bucket(self, bucket):
         """

--- a/tinys3/request_factory.py
+++ b/tinys3/request_factory.py
@@ -35,14 +35,19 @@ class S3Request(object):
         self.tls = conn.tls
         self.endpoint = conn.endpoint
         self.params = params
+        self.bucket_url_format = conn.bucket_url_format
 
     def bucket_url(self, key, bucket):
         """Function to generate the request URL. Is used by every request"""
         protocol = 'https' if self.tls else 'http'
         key = stringify(key)
         bucket = stringify(bucket)
-        url = "{0}://{1}.{2}/{3}".format(protocol, bucket, self.endpoint,
-                                         key.lstrip('/'))
+        if self.bucket_url_format == 'BUCKET_URL_FORMAT_SUBDOMAIN':
+            url = "{0}://{1}.{2}/{3}".format(protocol, bucket, self.endpoint,
+                                             key.lstrip('/'))
+        else:#BUCKET_URL_FORMAT_FOLDER
+            url = "{0}://{1}/{2}/{3}".format(protocol, self.endpoint, bucket,
+                                             key.lstrip('/'))
         # If params have been specified, add them to URL in the format :
         # url?param1&param2=value, etc.
         if self.params is not None:

--- a/tinys3/tests/test_upload_request.py
+++ b/tinys3/tests/test_upload_request.py
@@ -46,10 +46,35 @@ class TestUploadRequest(unittest.TestCase):
 
         mock.should_receive('put').with_args(
             'https://bucket.s3.amazonaws.com/upload_key',
-            # 'https://s3.amazonaws.com/bucket/upload_key',
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
+        ).and_return(self._mock_response()).once()
+
+        r.run()
+
+    def test_upload_format_folder(self):
+        """
+        Test upload using another bucket url format
+        """
+
+        connection = Connection("TEST_ACCESS_KEY", "TEST_SECRET_KEY", tls=True,
+                                bucket_url_format=Connection.BUCKET_URL_FORMAT_FOLDER)
+
+        r = UploadRequest(connection, 'upload_key', self.dummy_data, 'bucket')
+
+        mock = self._mock_adapter(r)
+
+        expected_headers = {
+            'x-amz-acl': 'public-read',
+            'Content-Type': 'application/octet-stream'
+        }
+
+        mock.should_receive('put').with_args(
+            'https://s3.amazonaws.com/bucket/upload_key',
+            headers=expected_headers,
+            data=self.dummy_data,
+            auth=connection.auth
         ).and_return(self._mock_response()).once()
 
         r.run()
@@ -80,7 +105,6 @@ class TestUploadRequest(unittest.TestCase):
         }
 
         mock.should_receive('put').with_args(
-            #  'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,
@@ -100,7 +124,6 @@ class TestUploadRequest(unittest.TestCase):
         }
 
         mock.should_receive('put').with_args(
-            # 'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,
@@ -128,7 +151,6 @@ class TestUploadRequest(unittest.TestCase):
 
         mock.should_receive('put').with_args(
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
-            # 'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,
             auth=self.conn.auth
@@ -148,7 +170,6 @@ class TestUploadRequest(unittest.TestCase):
         }
 
         mock.should_receive('put').with_args(
-            # 'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,
@@ -170,7 +191,6 @@ class TestUploadRequest(unittest.TestCase):
         }
 
         mock.should_receive('put').with_args(
-            # 'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,
@@ -196,7 +216,6 @@ class TestUploadRequest(unittest.TestCase):
         }
 
         mock.should_receive('put').with_args(
-            # 'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,
@@ -221,7 +240,6 @@ class TestUploadRequest(unittest.TestCase):
         }
 
         mock.should_receive('put').with_args(
-            # 'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,
@@ -251,7 +269,6 @@ class TestUploadRequest(unittest.TestCase):
         }
 
         mock.should_receive('put').with_args(
-            # 'https://s3.amazonaws.com/bucket/test_zip_key.zip',
             'https://bucket.s3.amazonaws.com/test_zip_key.zip',
             headers=expected_headers,
             data=self.dummy_data,


### PR DESCRIPTION
This option is necessary to use lib with buckets with dots (".") in name.
Fixes #52 