### PR TITLE
Private should be default for security purposes #44

### DIFF
--- a/tinys3/connection.py
+++ b/tinys3/connection.py
@@ -112,7 +112,7 @@ class Base(object):
 
     def upload(self, key, local_file,
                bucket=None, expires=None, content_type=None,
-               public=True, headers=None, rewind=True, close=False):
+               public=False, headers=None, rewind=True, close=False):
         """
         Upload a file and store it under a key
 
@@ -171,7 +171,7 @@ class Base(object):
         return self.run(r)
 
     def copy(self, from_key, from_bucket, to_key, to_bucket=None,
-             metadata=None, public=True):
+             metadata=None, public=False):
         """
         Copy a key contents to another key/bucket with an option to update
         metadata/public state
@@ -204,7 +204,7 @@ class Base(object):
                         metadata=metadata, public=public)
         return self.run(r)
 
-    def update_metadata(self, key, metadata=None, bucket=None, public=True):
+    def update_metadata(self, key, metadata=None, bucket=None, public=False):
         """
         Updates the metadata information for a file
 

--- a/tinys3/connection.py
+++ b/tinys3/connection.py
@@ -136,7 +136,7 @@ class Base(object):
               for the file (using the mimetypes lib)
 
             - public        (Optional) If set to true, tinys3 will set the file
-              to be publicly available using the acl headers. Defaults to True.
+              to be publicly available using the acl headers. Defaults to False.
 
             - headers       (Optional) Allows you to specify extra headers for
               the request using a dict.
@@ -186,7 +186,7 @@ class Base(object):
               metadata. if not defined, tinys3 will copy the source key's
               metadata.
             - public        (Optional) Same as upload, should the new key be
-              publicly accessible? Default to True.
+              publicly accessible? Default to False.
 
         Returns:
             - A response object from the requests lib or a future that wraps
@@ -212,7 +212,7 @@ class Base(object):
             - key           The key to update
             - metadata      (Optional) The metadata dict to set for the key
             - public        (Optional) Same as upload, should the key be
-              publicly accessible? Default to True.
+              publicly accessible? Default to False.
 
         Returns:
             - A response object from the requests lib or a future that wraps

--- a/tinys3/request_factory.py
+++ b/tinys3/request_factory.py
@@ -282,7 +282,7 @@ class HeadRequest(S3Request):
 
 class UploadRequest(S3Request):
     def __init__(self, conn, key, local_file, bucket, expires=None,
-                 content_type=None, public=True, extra_headers=None,
+                 content_type=None, public=False, extra_headers=None,
                  close=False, rewind=True):
         """
         :param conn:
@@ -452,7 +452,7 @@ class CancelUploadRequest(S3Request):
 class CopyRequest(S3Request):
 
     def __init__(self, conn, from_key, from_bucket, to_key, to_bucket,
-                 metadata=None, public=True):
+                 metadata=None, public=False):
         super(CopyRequest, self).__init__(conn)
         # stringify + quote combo is to correctly manage Unicode filenames
         # (they must be encoded like within an URL)
@@ -484,7 +484,7 @@ class CopyRequest(S3Request):
 
 
 class UpdateMetadataRequest(CopyRequest):
-    def __init__(self, conn, key, bucket, metadata=None, public=True):
+    def __init__(self, conn, key, bucket, metadata=None, public=False):
         super(UpdateMetadataRequest, self).__init__(conn, key, bucket, key,
                                                     bucket, metadata=metadata,
                                                     public=public)


### PR DESCRIPTION
As the title says. This aligns with the security best practise of least privilege.